### PR TITLE
fix crash if no genres found

### DIFF
--- a/plugin/beets/beetsplug/wlg.py
+++ b/plugin/beets/beetsplug/wlg.py
@@ -139,7 +139,10 @@ class WhatLastGenre(BeetsPlugin):
             year=album.year, releasetype=album.albumtype)
 
         genres, _ = self.wlg.query_album(metadata)
-        genres = self.config['separator'].get(unicode).join(genres)
+        try:
+            genres = self.config['separator'].get(unicode).join(genres)
+            self._log.info(u'genres for album {0}: {1}', album, genres)
+        except TypeError:
+            self._log.info(u'No genres found for album {0}', album) 
 
-        self._log.info(u'genres for album {0}: {1}', album, genres)
         return genres


### PR DESCRIPTION
I found a local metal band's demo and it crashed because none of the genre providers had ever heard of it. So I made a quick fix to make it at least not crash when the beets plugin was going.