### PR TITLE
Removing support for What.CD, adding Redacted.ch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Improve genre metadata of audio files based on tags from various music sites.
 
 * Supported audio files: flac, ogg, mp3, m4a
-* Supported music sites: Discogs, Last.FM, MusicBrainz, What.CD
+* Supported music sites: Discogs, Last.FM, MusicBrainz, Redacted.ch
 * Feature Overview
   * Gets genre tags for artists and albums from music sites and finds the most
   eligible ones.
@@ -14,7 +14,7 @@ Improve genre metadata of audio files based on tags from various music sites.
     * Scores tags while taking personal preferences into account
   * Caches all data received from music sites to speedup reruns
   * Uses MusicBrainz IDs for searching when available
-  * Optional: gets release info from whatcd (with interactivity if ambiguous)
+  * Optional: gets release info from redacted (with interactivity if ambiguous)
   * Can be used as plugin in other software, currently:
   [beets](https://github.com/beetbox/beets)
   * Dry-mode for safe testing
@@ -34,14 +34,14 @@ preferences into account. Please take a look at "Configuration options
 explained" below for more details.
 
 ##### Tag scoring with counts/weights
-    lastfm, mbrainz, whatcd artist
+    lastfm, mbrainz, redacted artist
 If counts are supplied for the tags they will get scored by `count/topcount`,
 where `topcount` is the highest count of all tags from a source. So the top
 tag gets a score of `1.0`, a tag having only half of the top tag's count gets
 a score of `0.5` and so on.
 
 ##### Tag scoring without counts/weights
-     discogs, whatcd album
+     discogs, redacted album
 Tags supplied without a count will be scored `max(1/3, 0.85^(n-1))`, where `n`
 is the total number of tags supplied by this source. The more tags the lower
 the score for each tag will be. So if only one tag is supplied, it will get a
@@ -74,7 +74,7 @@ option explained below.
 ##### Release info tagging and interactivity
     releasetype, year, label, catalog, edition, media
 Releaseinfo can be tagged for snatched torrents (make sure to enable 'Snatched
-torrents indicator' in your whatcd profile settings). Although prefiltering
+torrents indicator' in your redacted profile settings). Although prefiltering
 tries to minimize needed user input, some might be required in ambiguous cases
 while tagging releaseinfo. `-r` implies interactivity, `-n` disables
 interactivity. Be aware that `-r` saves the original release year into the
@@ -111,7 +111,7 @@ A configuration file with default values will be created at
 ### Example configuration file
 ```
 [wlg]
-sources = discogs, lastfm, whatcd
+sources = discogs, lastfm, redacted
 whitelist =
 tagsfile =
 vaqueries = True
@@ -127,11 +127,11 @@ minimum = 0.10
 src_discogs = 1.00
 src_lastfm = 0.66
 src_mbrainz = 0.66
-src_whatcd = 1.50
+src_redacted = 1.50
 [discogs]
 token =
 secret =
-[whatcd]
+[redacted]
 username =
 password =
 session =
@@ -147,7 +147,7 @@ Source | Artist | Album | Auth | ...
 [discogs](http://discogs.com) | 0 | 1 | 1 | fixed list of [genres and styles] (http://www.discogs.com/help/doc/submission-guidelines-release-genres-styles)
 [lastfm](http://last.fm)| 1 | 1 | 0 |  many personal tags from users
 [mbrainz](http://musicbrainz.org) | 1 | 1 | 0 | home of mbids (overstrained)
-[whatcd](https://what.cd) | 1 | 1 | 1 | well-kept tags from community
+[redacted](https://redacted.ch) | 1 | 1 | 1 | well-kept tags from community
 
 ##### whitelist/tagsfile option
 Path to your custom whitelist and tagsfile. Use shipped
@@ -236,7 +236,7 @@ Default `1.0`, see `sources` option above.
 ##### discogs token and secret options
 Authentication information for discogs, will be set interactively.
 
-##### whatcd username, password and session options
+##### redacted username, password and session options
 You can optionally store your username and/or password here. If you don't store
 them, you will be asked interactively every time the automatically stored
 session cookie expired (or does not exist yet).
@@ -255,7 +255,7 @@ optional arguments:
   -n, --dry            don't save metadata (default: False)
   -u, --update-cache   force cache update (default: False)
   -l N, --tag-limit N  max. number of genre tags (default: 4)
-  -r, --release        get release info from whatcd (default: False)
+  -r, --release        get release info from redacted (default: False)
   -d, --difflib        enable difflib matching (slow) (default: False)
 ```
 

--- a/test/test_dataprovider.py
+++ b/test/test_dataprovider.py
@@ -200,7 +200,7 @@ class TestMusicBrainzDataProvider(DataProviderTestCase):
         self.assertEqual(res['id'], mbid)
 
 
-class TestWhatCDDataProvider(DataProviderTestCase):
+class TestRedactedDataProvider(DataProviderTestCase):
     results = {
         'artist': [
             (1, 97),
@@ -214,12 +214,12 @@ class TestWhatCDDataProvider(DataProviderTestCase):
     @classmethod
     def setUpClass(cls):
         conf = get_config()
-        if conf.get('whatcd', 'session') or (
-                    conf.get('whatcd', 'username') and
-                    conf.get('whatcd', 'password')):
-            cls.dapr = wlg.dataprovider.WhatCD(conf)
+        if conf.get('redacted', 'session') or (
+                    conf.get('redacted', 'username') and
+                    conf.get('redacted', 'password')):
+            cls.dapr = wlg.dataprovider.Redacted(conf)
         else:
-            raise unittest.SkipTest('no whatcd auth')
+            raise unittest.SkipTest('no redacted auth')
 
     def test_api(self):
         res = self.dapr._query({'action': 'index'})

--- a/wlg/whatlastgenre.py
+++ b/wlg/whatlastgenre.py
@@ -213,7 +213,7 @@ class WhatLastGenre(object):
             # ask user if appropriated
             if len(results) > 1 and not self.conf.args.dry \
                     and self.conf.args.release \
-                    and query.dapr.name.lower() == 'whatcd' \
+                    and query.dapr.name.lower() == 'redacted' \
                     and query.type == 'album' \
                     and len(set(r.get('releasetype') for r in results)) > 1:
                 results = ask_user(query.dapr.name, query.type, results)
@@ -252,7 +252,7 @@ class WhatLastGenre(object):
             else:
                 status = "no    tags"
             # release info
-            if query.dapr.name.lower() == 'whatcd' and query.type == 'album':
+            if query.dapr.name.lower() == 'redacted' and query.type == 'album':
                 if 'releasetype' in results[0] and results[0]['releasetype']:
                     self.stats.reltyps[results[0]['releasetype']] += 1
                     release = {k: v for k, v in results[0].iteritems()
@@ -639,7 +639,7 @@ class Config(ConfigParser.SafeConfigParser):
     """Read, maintain and write the configuration file."""
 
     # (section, option, value)
-    conf = [('wlg', 'sources', 'discogs, lastfm, whatcd'),
+    conf = [('wlg', 'sources', 'discogs, lastfm, redacted'),
             ('wlg', 'whitelist', ''),
             ('wlg', 'tagsfile', ''),
             ('wlg', 'vaqueries', 'true'),
@@ -653,12 +653,12 @@ class Config(ConfigParser.SafeConfigParser):
             ('scores', 'src_discogs', '1.00'),
             ('scores', 'src_lastfm', '0.66'),
             ('scores', 'src_mbrainz', '0.66'),
-            ('scores', 'src_whatcd', '1.50'),
+            ('scores', 'src_redacted', '1.50'),
             ('discogs', 'token', ''),
             ('discogs', 'secret', ''),
-            ('whatcd', 'username', ''),
-            ('whatcd', 'password', ''),
-            ('whatcd', 'session', ''),
+            ('redacted', 'username', ''),
+            ('redacted', 'password', ''),
+            ('redacted', 'session', ''),
             ]
 
     def __init__(self, args):
@@ -681,8 +681,8 @@ class Config(ConfigParser.SafeConfigParser):
         self.read(self.fullpath)
         self.__compat()
         # validation
-        if args.release and 'whatcd' not in self.get_list('wlg', 'sources'):
-            self.log.warning('Can\'t tag release with What.CD support '
+        if args.release and 'redacted' not in self.get_list('wlg', 'sources'):
+            self.log.warning('Can\'t tag release with Redacted.ch support '
                              'disabled. Release tagging disabled.')
             self.args.release = False
 
@@ -844,7 +844,7 @@ def get_args():
     parser.add_argument('-l', '--tag-limit', metavar='N', type=int, default=4,
                         help='max. number of genre tags')
     parser.add_argument('-r', '--release', action='store_true',
-                        help='get release info from whatcd')
+                        help='get release info from redacted')
     parser.add_argument('-d', '--difflib', action='store_true',
                         help='enable difflib matching (slow)')
     return parser.parse_args()


### PR DESCRIPTION
What.CD has officially shutdown, Redacted.ch is one successor. They both use the
same API. This commit switches from What.CD to Redacted.