### PR TITLE
Added -m switch for massive search

### DIFF
--- a/wlg/mediafile.py
+++ b/wlg/mediafile.py
@@ -110,13 +110,14 @@ class Album(object):
         for file_ in os.listdir(path):
             if os.path.splitext(file_)[1].lower() in EXTENSIONS:
                 try:
-                    self.tracks.append(Track(path, file_, v23sep))
+                     self.tracks.append(Track(path, file_, v23sep))
                 except TrackError as err:
                     print("Error loading track '%s': %s" % (file_, err))
         if not self.tracks:
             raise AlbumError("Could not load any tracks")
-        if not self.get_meta('album'):
-            raise AlbumError("Not all tracks have the same or any album-tag")
+        #TODO access command argument here
+        #if not self.get_meta('album'):
+            #raise AlbumError("Not all tracks have the same or any album-tag")
         self.type = ','.join(set(t.ext for t in self.tracks)).upper()
 
     def get_metadata(self):

--- a/wlg/whatlastgenre.py
+++ b/wlg/whatlastgenre.py
@@ -48,7 +48,6 @@ Stats = namedtuple('Stats', ['time', 'messages', 'genres', 'reltyps'])
 
 class WhatLastGenre(object):
     """Main class featuring a docstring that needs to be written."""
-
     def __init__(self, conf):
         self.log = logging.getLogger('wlg')
         self.log.setLevel(30 - 10 * conf.args.verbose)
@@ -62,7 +61,6 @@ class WhatLastGenre(object):
         self.daprs = self.init_dataproviders()
         self.whitelist = self.read_whitelist()
         self.tags = self.read_tagsfile()
-
     def read_whitelist(self, path=None):
         """Read the whitelist trying different paths.
 
@@ -329,8 +327,9 @@ class WhatLastGenre(object):
     def create_queries(self, metadata):
         """Create queries for all DataProviders based on metadata."""
         artists = metadata.artists
-        if len(set(artists)) > 42:
-            self.log.warn('Too many artists for va-artist search')
+
+        if len(set(artists)) > 42 and not self.conf.args.massive:
+            self.log.warn('Too many artists for va-artist search. Use -m for massive search')
             artists = []
         albumartist = searchstr(metadata.albumartist[0])
         album = searchstr(metadata.album)
@@ -850,6 +849,8 @@ def get_args():
                         help='get release info from redacted')
     parser.add_argument('-d', '--difflib', action='store_true',
                         help='enable difflib matching (slow)')
+    parser.add_argument('-m', '--massive', action='store_true',
+                        help='enable massive track tagging and ignore album tags')
     return parser.parse_args()
 
 


### PR DESCRIPTION
Background of this PR is Issue #31. Whatlastgenre doesn't support more than 42 artists searches and will always look if tracks in the same directory belong to the same album. This will add a new option -m (--massive) to request tags for much more songs and artists. 

Known limitations:

wlg/mediafile.py line 119
```
if not self.get_meta('album'):
            raise AlbumError("Not all tracks have the same or any album-tag")
```
will be commented to allow all tracks to be added to a query.

Any help to circumvent this problem would be appreciated.