### PR TITLE
Update to "state of the art" beets plugin installation method

### DIFF
--- a/plugin/beets/README.md
+++ b/plugin/beets/README.md
@@ -10,10 +10,7 @@ Install and configure beets and whatlastgenre according to its docs.
 
 Run whatlastgenre standalone to see if it is working.
 
-Configure beets to use the wlg plugin, for example (adjust path):
-
-    pluginpath:
-        ~/git/whatlastgenre/plugin/beets/beetsplug
+The beets plugin is registered to the `beetsplug` namespace automatically when whatlastgenre was installed via pip.
 
     plugins: wlg
 
@@ -24,6 +21,12 @@ Configure beets to use the wlg plugin, for example (adjust path):
 If you didn't install whatlastgenre, make sure to have it in PYTHONPATH:
 
     export PYTHONPATH="${PYTHONPATH}:~/git/whatlastgenre"
+
+In that case you also must configure beets to point to the plugin's path, for example:
+
+    pluginpath:
+        ~/git/whatlastgenre/plugin/beets/beetsplug
+
 
 See also: [beets doc about plugins](https://beets.readthedocs.io/en/latest/plugins/index.html)
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ setup(
     description=('Improves genre metadata of audio files '
                  'based on tags from various music sites.'),
     long_description=read('README.md'),
-    packages=['wlg'],
+    packages=['wlg', 'beetsplug',],
+    package_dir={'beetsplug': 'plugin/beets/beetsplug'},
     package_data={'wlg': ['data/genres.txt', 'data/tags.txt']},
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Usually for modern beets plugins, no manual setup via the beets config `beetsplug: ` directive should be required. This updates the plugin to fit that standard by using the `package_dir` directive in setup.py and registering to the beets' default plugin namespace `beetsplug`

The README of the plugin is adapted accordingly as well.

Further details on the topics: https://beets.readthedocs.io/en/latest/dev/plugins.html#writing-plugins, https://docs.python.org/3.11/distutils/setupscript.html#listing-whole-packages